### PR TITLE
Prepare repository to be built by appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 1.0.8.{build}
+image: Visual Studio 2017
+configuration: Release
+assembly_info:
+  patch: true
+  file: '**\SharedAssemblyInfo.cs'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+before_build:
+- ps: >-
+    ./scripts/appveyor-prebuild.ps1
+
+    nuget restore "src\TumblThree\TumblThree.sln"
+build:
+  project: src\TumblThree\TumblThree.sln
+  verbosity: normal
+after_build:
+- ps: ./scripts/appveyor-postbuild.ps1
+artifacts:
+- path: artifacts/*.zip
+  name: TumblThree

--- a/scripts/appveyor-postbuild.ps1
+++ b/scripts/appveyor-postbuild.ps1
@@ -1,0 +1,32 @@
+# Harvest Data
+$harvestPath = "$env:APPVEYOR_BUILD_FOLDER\src\TumblThree\TumblThree.Presentation\bin\Release"
+$fileVersion = (Get-Item "$harvestPath\TumblThree.exe").VersionInfo.ProductVersion
+
+# Artifacts Paths
+$artifactsPath = "$env:APPVEYOR_BUILD_FOLDER\artifacts"
+$applicationArtifactsPath = "$artifactsPath\Application\TumbleThree"
+$translationArtifactsPath = "$artifactsPath\Translations\TumbleThree"
+
+New-Item -ItemType Directory -Force -Path $applicationArtifactsPath
+New-Item -ItemType Directory -Force -Path $translationArtifactsPath
+
+# Copy in Application Artifacts
+Get-ChildItem -Path "$harvestPath\*" -Include *.exe,*.dll,*.config | Copy-Item -Destination $applicationArtifactsPath
+New-Item -ItemType Directory -Force -Path "$applicationArtifactsPath\en"
+Get-ChildItem -Path "$harvestPath\en\*" | Copy-Item -Destination "$applicationArtifactsPath\en"
+
+# Copy in Translation Artifacts
+$translationFolders = dir -Directory $harvestPath
+foreach ($tf in $translationFolders) {
+    $tfTarget = "$translationArtifactsPath\$tf"
+    New-Item -ItemType Directory -Force -Path "$tfTarget"
+    Get-ChildItem -Path "$harvestPath\$tf\*" | Copy-Item -Destination "$tfTarget"
+}
+
+# Zip Application
+$applicationZipPath = "$artifactsPath\TumblThree-v$fileVersion-Application.zip"
+Compress-Archive -Path "$artifactsPath\Application\TumbleThree\" -DestinationPath "$applicationZipPath"
+
+# Zip Translations
+$translationZipPath = "$artifactsPath\TumblThree-v$fileVersion-Translations.zip"
+Compress-Archive -Path "$artifactsPath\Translations\TumbleThree\" -DestinationPath "$translationZipPath"

--- a/src/TumblThree/SharedAssemblyInfo.cs
+++ b/src/TumblThree/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.MainAssembly)]
-[assembly: AssemblyVersion("1.0.8.68")]
-[assembly: AssemblyFileVersion("1.0.8.68")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]


### PR DESCRIPTION
Implement changes to support AppVeyor building TumblThree.

- AppVeyor configuration file (this now manages version)
- Pre-build script
- Post-build script
- Reset version in primary AssemblyInfo file to reduce confusion with local builds. 

- Remote service configuration