### PR TITLE
Retarget all projects to .Net 4.7.2

### DIFF
--- a/lib/RateLimiter/RateLimiter/RateLimiter.csproj
+++ b/lib/RateLimiter/RateLimiter/RateLimiter.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Guava.RateLimiter</RootNamespace>
     <AssemblyName>Guava.RateLimiter</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/lib/WpfApplicationFramework/WpfApplicationFramework/WpfApplicationFramework.csproj
+++ b/lib/WpfApplicationFramework/WpfApplicationFramework/WpfApplicationFramework.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Waf</RootNamespace>
     <AssemblyName>WpfApplicationFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/src/TumblThree/TumblThree.Applications/App.config
+++ b/src/TumblThree/TumblThree.Applications/App.config
@@ -1,16 +1,14 @@
-﻿<?xml
-  version="1.0"
-  encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 
   <runtime>
-    <loadFromRemoteSources enabled="true" />
-    <ThrowUnobservedTaskExceptions enabled="false" />
+    <loadFromRemoteSources enabled="true"/>
+    <ThrowUnobservedTaskExceptions enabled="false"/>
   </runtime>
   <system.net>
-    <defaultProxy enabled="true" useDefaultCredentials="true" />
+    <defaultProxy enabled="true" useDefaultCredentials="true"/>
   </system.net>
 </configuration>

--- a/src/TumblThree/TumblThree.Applications/Properties/Settings.Designer.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TumblThree.Applications.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
+++ b/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TumblThree.Applications</RootNamespace>
     <AssemblyName>TumblThree.Applications</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/TumblThree/TumblThree.Domain/App.config
+++ b/src/TumblThree/TumblThree.Domain/App.config
@@ -1,16 +1,15 @@
-<?xml
-  version="1.0"?>
+<?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 
   <runtime>
-    <loadFromRemoteSources enabled="true" />
-    <ThrowUnobservedTaskExceptions enabled="false" />
+    <loadFromRemoteSources enabled="true"/>
+    <ThrowUnobservedTaskExceptions enabled="false"/>
   </runtime>
 
   <system.net>
-    <defaultProxy enabled="true" useDefaultCredentials="true" />
+    <defaultProxy enabled="true" useDefaultCredentials="true"/>
   </system.net>
 </configuration>

--- a/src/TumblThree/TumblThree.Domain/Properties/Resources.Designer.cs
+++ b/src/TumblThree/TumblThree.Domain/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace TumblThree.Domain.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {

--- a/src/TumblThree/TumblThree.Domain/Properties/Settings.Designer.cs
+++ b/src/TumblThree/TumblThree.Domain/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TumblThree.Domain.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/TumblThree/TumblThree.Domain/TumblThree.Domain.csproj
+++ b/src/TumblThree/TumblThree.Domain/TumblThree.Domain.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TumblThree.Domain</RootNamespace>
     <AssemblyName>TumblThree.Domain</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/TumblThree/TumblThree.Presentation/App.config
+++ b/src/TumblThree/TumblThree.Presentation/App.config
@@ -2,29 +2,29 @@
 <configuration>
   <configSections>
     <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="TumblThree.Presentation.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+      <section name="TumblThree.Presentation.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     </sectionGroup>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 
   <runtime>
-    <loadFromRemoteSources enabled="true" />
-    <ThrowUnobservedTaskExceptions enabled="false" />
+    <loadFromRemoteSources enabled="true"/>
+    <ThrowUnobservedTaskExceptions enabled="false"/>
   </runtime>
   <applicationSettings>
     <TumblThree.Presentation.Properties.Settings>
       <setting name="Culture" serializeAs="String">
-        <value />
+        <value/>
       </setting>
       <setting name="UICulture" serializeAs="String">
-        <value />
+        <value/>
       </setting>
     </TumblThree.Presentation.Properties.Settings>
   </applicationSettings>
 
   <system.net>
-    <defaultProxy enabled="true" useDefaultCredentials="true" />
+    <defaultProxy enabled="true" useDefaultCredentials="true"/>
   </system.net>
 </configuration>

--- a/src/TumblThree/TumblThree.Presentation/Properties/Settings.Designer.cs
+++ b/src/TumblThree/TumblThree.Presentation/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TumblThree.Presentation.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/TumblThree/TumblThree.Presentation/TumblThree.Presentation.csproj
+++ b/src/TumblThree/TumblThree.Presentation/TumblThree.Presentation.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TumblThree.Presentation</RootNamespace>
     <AssemblyName>TumblThree</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -47,9 +47,6 @@
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
-      <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -302,7 +299,6 @@
     <EmbeddedResource Include="Properties\Resources.vi.resx" />
     <EmbeddedResource Include="Properties\Resources.zh.resx" />
     <None Include="App.config" />
-    <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
@@ -362,6 +358,11 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\Images\Play.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FontAwesome.WPF">
+      <Version>4.7.0.9</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/TumblThree/TumblThree.Presentation/packages.config
+++ b/src/TumblThree/TumblThree.Presentation/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FontAwesome.WPF" version="4.7.0.9" targetFramework="net46" />
-</packages>


### PR DESCRIPTION
Retarget all projects to .Net 4.7.2 and move to new Nuget format (PackageReference). This addresses issue #8. Ensure your dev environment is up to date. You may need to close and reopen the solution if Nuget packages (just FontAwesome at this stage) are problematic.

This should simplify some other issues that are nuget dependent: Logging; Tumblr Repo Format; Coding Standard; etc.