### PR TITLE
issue #99 Plenty System.NotImplementedExceptions

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Downloader/TumblrJsonDownloader.cs
+++ b/src/TumblThree/TumblThree.Applications/Downloader/TumblrJsonDownloader.cs
@@ -88,7 +88,8 @@ namespace TumblThree.Applications.Downloader
                     {
                         var serializer = new DataContractJsonSerializer(data.GetType());
                         serializer.WriteObject(writer, data);
-                        await writer.FlushAsync();
+                        writer.Flush();
+                        await Task.CompletedTask;
                     }
                 }
             }


### PR DESCRIPTION
## Description

While crawling a few blogs dozens of System.NotImplementedExceptions are showing up in Visual Studio's log window. But all files seem to be downloaded.

## Issue Resolution

This Pull Request Fixes issue #99 Plenty System.NotImplementedExceptions

## Proposed Changes

 - instead of XmlDictionaryWriter.FlushAsync() use sync XmlDictionaryWriter.Flush(). FlushAsync is not implemented for the XmlWriter (ref https://github.com/microsoft/referencesource/blob/master/System.Xml/System/Xml/Core/XmlWriterAsync.cs). 
Async alternative is available only in .NET 5.0 or .NET Core 3.0 - https://docs.microsoft.com/ru-ru/dotnet/api/system.text.json.jsonserializer.serializeasync?view=net-5.0.
- return Task.CompletedTask after calling XmlDictionaryWriter.Flush() so existing logic would remain the same.
