### PR TITLE
Issue #124: Color cues

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
+++ b/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
@@ -749,7 +749,7 @@ namespace TumblThree.Applications.Controllers
             catch (Exception ex)
             {
                 Logger.Error($"ManagerController:OnClipboardContentChanged: {ex}");
-                _shellService.ShowError(ex, "error getting clipboard content");
+                _shellService.ShowError(new ClipboardContentException(ex), "error getting clipboard content");
             }
         }
 

--- a/src/TumblThree/TumblThree.Applications/Controllers/QueueController.cs
+++ b/src/TumblThree/TumblThree.Applications/Controllers/QueueController.cs
@@ -148,7 +148,7 @@ namespace TumblThree.Applications.Controllers
             catch (Exception ex)
             {
                 Logger.Error("QueueController:OpenListCore: {0}", ex);
-                _shellService.ShowError(ex, Resources.CouldNotLoadQueuelist);
+                _shellService.ShowError(new QueuelistLoadException(ex), Resources.CouldNotLoadQueuelist);
                 return;
             }
 
@@ -164,7 +164,7 @@ namespace TumblThree.Applications.Controllers
             catch (Exception ex)
             {
                 Logger.Error("QueueController.InsertFileCore: {0}", ex);
-                _shellService.ShowError(ex, Resources.CouldNotLoadQueuelist);
+                _shellService.ShowError(new QueuelistLoadException(ex), Resources.CouldNotLoadQueuelist);
             }
         }
 
@@ -200,7 +200,7 @@ namespace TumblThree.Applications.Controllers
             catch (Exception ex)
             {
                 Logger.Error("QueueController:SaveList: {0}", ex);
-                _shellService.ShowError(ex, Resources.CouldNotSaveQueueList);
+                _shellService.ShowError(new QueuelistSaveException(ex), Resources.CouldNotSaveQueueList);
             }
         }
 

--- a/src/TumblThree/TumblThree.Applications/Converter/BrushResourceConverter.cs
+++ b/src/TumblThree/TumblThree.Applications/Converter/BrushResourceConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace TumblThree.Applications.Converter
+{
+    public class BrushResourceConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string s = (string) value;
+            return Application.Current.Resources.MergedDictionaries.Where(r => r.Source.ToString() == "Resources/BrushResources.xaml").FirstOrDefault()[s];
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/Converter/BrushResourceConverter.cs
+++ b/src/TumblThree/TumblThree.Applications/Converter/BrushResourceConverter.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
-using System.Windows.Media;
 
 namespace TumblThree.Applications.Converter
 {
@@ -21,7 +20,7 @@ namespace TumblThree.Applications.Converter
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractCrawler.cs
@@ -133,7 +133,7 @@ namespace TumblThree.Applications.Crawler
                         if (url.Contains("privacy/consent"))
                         {
                             var ex = new Exception("Acceptance of privacy consent needed!");
-                            ShellService.ShowError(ex, Resources.ConfirmationTumblrPrivacyConsentNeeded);
+                            ShellService.ShowError(new TumblrPrivacyConsentException(ex), Resources.ConfirmationTumblrPrivacyConsentNeeded);
                             throw ex;
                         }
                         if (!url.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))

--- a/src/TumblThree/TumblThree.Applications/ErrorExceptions.cs
+++ b/src/TumblThree/TumblThree.Applications/ErrorExceptions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace TumblThree.Applications
 {
@@ -10,36 +7,84 @@ namespace TumblThree.Applications
     [Serializable]
     public class ClipboardContentException : Exception
     {
-        public ClipboardContentException(Exception innerException) : base(null, innerException) { }
+        public ClipboardContentException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public ClipboardContentException() {  }
+
+        public ClipboardContentException(string message) : base(message)  {  }
+
+        public ClipboardContentException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected ClipboardContentException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]
     public class QueuelistLoadException : Exception
     {
-        public QueuelistLoadException(Exception innerException) : base(null, innerException) { }
+        public QueuelistLoadException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public QueuelistLoadException() { }
+
+        public QueuelistLoadException(string message) : base(message) { }
+
+        public QueuelistLoadException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected QueuelistLoadException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]
     public class QueuelistSaveException : Exception
     {
-        public QueuelistSaveException(Exception innerException) : base(null, innerException) { }
+        public QueuelistSaveException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public QueuelistSaveException() { }
+
+        public QueuelistSaveException(string message) : base(message) { }
+
+        public QueuelistSaveException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected QueuelistSaveException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]
     public class TumblrPrivacyConsentException : Exception
     {
-        public TumblrPrivacyConsentException(Exception innerException) : base(null, innerException) { }
+        public TumblrPrivacyConsentException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public TumblrPrivacyConsentException() { }
+
+        public TumblrPrivacyConsentException(string message) : base(message) { }
+
+        public TumblrPrivacyConsentException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected TumblrPrivacyConsentException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]
     public class DiskFullException : Exception
     {
-        public DiskFullException(Exception innerException) : base(null, innerException) { }
+        public DiskFullException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public DiskFullException() { }
+
+        public DiskFullException(string message) : base(message) { }
+
+        public DiskFullException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected DiskFullException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Serializable]
     public class UISettingsException : Exception
     {
-        public UISettingsException(Exception innerException) : base(null, innerException) { }
+        public UISettingsException(Exception innerException) : base(innerException?.Message, innerException) { }
+
+        public UISettingsException() { }
+
+        public UISettingsException(string message) : base(message) { }
+
+        public UISettingsException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected UISettingsException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/ErrorExceptions.cs
+++ b/src/TumblThree/TumblThree.Applications/ErrorExceptions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TumblThree.Applications
+{
+
+    [Serializable]
+    public class ClipboardContentException : Exception
+    {
+        public ClipboardContentException(Exception innerException) : base(null, innerException) { }
+    }
+
+    [Serializable]
+    public class QueuelistLoadException : Exception
+    {
+        public QueuelistLoadException(Exception innerException) : base(null, innerException) { }
+    }
+
+    [Serializable]
+    public class QueuelistSaveException : Exception
+    {
+        public QueuelistSaveException(Exception innerException) : base(null, innerException) { }
+    }
+
+    [Serializable]
+    public class TumblrPrivacyConsentException : Exception
+    {
+        public TumblrPrivacyConsentException(Exception innerException) : base(null, innerException) { }
+    }
+
+    [Serializable]
+    public class DiskFullException : Exception
+    {
+        public DiskFullException(Exception innerException) : base(null, innerException) { }
+    }
+
+    [Serializable]
+    public class UISettingsException : Exception
+    {
+        public UISettingsException(Exception innerException) : base(null, innerException) { }
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/Services/ConfirmTumblrPrivacyConsent.cs
+++ b/src/TumblThree/TumblThree.Applications/Services/ConfirmTumblrPrivacyConsent.cs
@@ -42,7 +42,7 @@ namespace TumblThree.Applications.Services
             catch (Exception exception)
             {
                 Logger.Error("{0}, {1}", string.Format(CultureInfo.CurrentCulture, Resources.ConfirmingTumblrPrivacyConsentFailed), exception);
-                shellService.ShowError(exception, Resources.ConfirmingTumblrPrivacyConsentFailed);
+                shellService.ShowError(new TumblrPrivacyConsentException(exception), Resources.ConfirmingTumblrPrivacyConsentFailed);
             }
         }
 

--- a/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
+++ b/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Controllers\ManagerController.cs" />
     <Compile Include="Controllers\ModuleController.cs" />
     <Compile Include="Controllers\QueueController.cs" />
+    <Compile Include="Converter\BrushResourceConverter.cs" />
     <Compile Include="Converter\PropertyCopier.cs" />
     <Compile Include="Converter\SingleOrArrayConverter.cs" />
     <Compile Include="CookieParser.cs" />
@@ -131,6 +132,7 @@
     <Compile Include="DataModels\TumblrSearch\TumblrSearchJson.cs" />
     <Compile Include="DataModels\TumblrTaggedSearch\TumblrTaggedSearchJson.cs" />
     <Compile Include="Downloader\TumblrJsonDownloader.cs" />
+    <Compile Include="ErrorExceptions.cs" />
     <Compile Include="Parser\CatBoxParser.cs" />
     <Compile Include="Parser\GfycatParser.cs" />
     <Compile Include="Parser\ICatBoxParser.cs" />

--- a/src/TumblThree/TumblThree.Applications/ViewModels/ManagerViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/ManagerViewModel.cs
@@ -107,7 +107,7 @@ namespace TumblThree.Applications.ViewModels
             catch (Exception ex)
             {
                 Logger.Error("ManagerViewModel:ManagerViewModel {0}", ex);
-                ShellService.ShowError(ex, Resources.CouldNotRestoreUISettings);
+                ShellService.ShowError(new UISettingsException(ex), Resources.CouldNotRestoreUISettings);
                 return;
             }
         }

--- a/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Net;
-using System.Resources;
 using System.Waf.Applications;
 using System.Windows;
 using System.Windows.Input;
@@ -31,6 +30,7 @@ namespace TumblThree.Applications.ViewModels
         private readonly object _errorsLock = new object();
         private readonly AppSettings _settings;
         private readonly ExportFactory<SettingsViewModel> _settingsViewModelFactory;
+        private readonly ResourceDictionary _brushResources;
 
         private object _detailsView;
 
@@ -118,19 +118,19 @@ namespace TumblThree.Applications.ViewModels
             }
         }
 
-        public Brush LastErrorColor
+        public string LastErrorColorString
         {
             get {
-                ResourceDictionary res = Application.Current.Resources.MergedDictionaries.Where(r => r.Source.ToString() == "Resources/BrushResources.xaml").FirstOrDefault();
-
                 if (LastError != null)
                 {
-                    if (LastError.Item1 is TimeoutException) return (Brush) res["ErrorBackgroundPurple"];
+                    if (LastError.Item1 is TimeoutException) return "ErrorBackgroundPurple";
 
-                    if (LastError.Item1 is WebException) return (Brush) res["ErrorBackgroundRed"];
+                    if (LastError.Item1 is WebException) return "ErrorBackgroundRed";
+
+                    if (LastError.Item1 is DiskFullException) return "ErrorBackgroundGreen";
                 }
 
-                return (Brush) res["ErrorBackgroundBlue"];
+                return "ErrorBackgroundBlue";
             }
         }
 
@@ -176,7 +176,7 @@ namespace TumblThree.Applications.ViewModels
             }
             if(e.PropertyName == nameof(LastError))
             {
-                RaisePropertyChanged(nameof(LastErrorColor));
+                RaisePropertyChanged(nameof(LastErrorColorString));
             }
         }
 

--- a/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
@@ -7,9 +7,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Net;
 using System.Waf.Applications;
-using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media;
 using TumblThree.Applications.Properties;
 using TumblThree.Applications.Services;
 using TumblThree.Applications.Views;
@@ -30,7 +28,6 @@ namespace TumblThree.Applications.ViewModels
         private readonly object _errorsLock = new object();
         private readonly AppSettings _settings;
         private readonly ExportFactory<SettingsViewModel> _settingsViewModelFactory;
-        private readonly ResourceDictionary _brushResources;
 
         private object _detailsView;
 

--- a/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/ShellViewModel.cs
@@ -5,9 +5,12 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Linq;
+using System.Net;
+using System.Resources;
 using System.Waf.Applications;
+using System.Windows;
 using System.Windows.Input;
-
+using System.Windows.Media;
 using TumblThree.Applications.Properties;
 using TumblThree.Applications.Services;
 using TumblThree.Applications.Views;
@@ -115,6 +118,22 @@ namespace TumblThree.Applications.ViewModels
             }
         }
 
+        public Brush LastErrorColor
+        {
+            get {
+                ResourceDictionary res = Application.Current.Resources.MergedDictionaries.Where(r => r.Source.ToString() == "Resources/BrushResources.xaml").FirstOrDefault();
+
+                if (LastError != null)
+                {
+                    if (LastError.Item1 is TimeoutException) return (Brush) res["ErrorBackgroundPurple"];
+
+                    if (LastError.Item1 is WebException) return (Brush) res["ErrorBackgroundRed"];
+                }
+
+                return (Brush) res["ErrorBackgroundBlue"];
+            }
+        }
+
         public void Show() => ViewCore.Show();
 
         private void Close() => ViewCore.Close();
@@ -154,6 +173,10 @@ namespace TumblThree.Applications.ViewModels
             {
                 RaisePropertyChanged(nameof(IsDetailsViewVisible));
                 RaisePropertyChanged(nameof(IsQueueViewVisible));
+            }
+            if(e.PropertyName == nameof(LastError))
+            {
+                RaisePropertyChanged(nameof(LastErrorColor));
             }
         }
 

--- a/src/TumblThree/TumblThree.Presentation/Resources/BrushResources.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Resources/BrushResources.xaml
@@ -18,7 +18,13 @@
 
     <SolidColorBrush x:Key="DarkTransparentBackground" Color="#BFA0A0A0" />
 
-    <SolidColorBrush x:Key="ErrorBackground" Color="SkyBlue" />
+    <SolidColorBrush x:Key="ErrorBackgroundBlue" Color="SkyBlue" />
+    
+    <SolidColorBrush x:Key="ErrorBackgroundRed" Color="PaleVioletRed" />
+    
+    <SolidColorBrush x:Key="ErrorBackgroundPurple" Color="MediumPurple" />
+    
+    <SolidColorBrush x:Key="ErrorBackgroundGreen" Color="MediumSeaGreen" />
 
     <SolidColorBrush x:Key="DefaultBorderBrush" Color="White" />
 

--- a/src/TumblThree/TumblThree.Presentation/Resources/ControlResources.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Resources/ControlResources.xaml
@@ -62,6 +62,20 @@
         BasedOn="{StaticResource InplaceButtonStyle}"
         TargetType="Button">
         <Setter Property="Content" Value="&#xE10A;" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="Border" Background="{TemplateBinding Background}">
+                        <ContentPresenter Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#80FFFFFF" TargetName="Border" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style

--- a/src/TumblThree/TumblThree.Presentation/Views/ShellWindow.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Views/ShellWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:dd="clr-namespace:TumblThree.Presentation.DesignData"
         xmlns:ctrl="clr-namespace:TumblThree.Presentation.Controls"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:vm="clr-namespace:TumblThree.Applications.ViewModels;assembly=TumblThree.Applications"
+        xmlns:vm="clr-namespace:TumblThree.Applications.ViewModels;assembly=TumblThree.Applications" xmlns:l="http://schemas.microsoft.com/netfx/2009/xaml/presentation" xmlns:l1="clr-namespace:TumblThree.Applications.Converter;assembly=TumblThree.Applications"
         mc:Ignorable="d" Icon="{StaticResource TumblThreeIcon}" Width="800" Height="500"
         d:DataContext="{d:DesignInstance dd:SampleShellViewModel, IsDesignTimeCreatable=True}">
 
@@ -40,6 +40,11 @@
         <KeyBinding Command="{Binding CrawlerService.StopCommand}" Key="Space" Modifiers="Shift" />
     </Window.InputBindings>
 
+    <Window.Resources>
+        <l1:BrushResourceConverter x:Key="brushConverter">
+        </l1:BrushResourceConverter>
+    </Window.Resources>
+
     <Grid x:Name="grid">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -54,7 +59,7 @@
         </Grid.RowDefinitions>
 
         <Border Grid.ColumnSpan="3" Grid.Row="0" BorderBrush="Transparent" BorderThickness="0,0,0,1"
-                Background="{Binding LastErrorColor}">
+                Background="{Binding LastErrorColorString, Converter={StaticResource brushConverter}}">
             <Border.Style>
                 <Style TargetType="Border">
                     <Style.Triggers>

--- a/src/TumblThree/TumblThree.Presentation/Views/ShellWindow.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Views/ShellWindow.xaml
@@ -54,7 +54,7 @@
         </Grid.RowDefinitions>
 
         <Border Grid.ColumnSpan="3" Grid.Row="0" BorderBrush="Transparent" BorderThickness="0,0,0,1"
-                Background="{StaticResource ErrorBackground}">
+                Background="{Binding LastErrorColor}">
             <Border.Style>
                 <Style TargetType="Border">
                     <Style.Triggers>


### PR DESCRIPTION
## Title

Suggestion that the error message bar should change colour depending on which error is being presented.

## Description

The user is unable to see, at a glance, which kind of error is being shown by the error message bar, particularly when closing several errors in succession. At present, all error messages have a blue background.

It was suggested that a red colour would be appropriate if a blog was missing, and a purple/green colour for timeout errors.

To address this, new colour resources should be added, and there should be a way for the error bar background to dynamically change in colour depending on the exception that is passed through.

## Issue Resolution

This Pull Request Fixes #124 Color cues

## Proposed Changes

- In BrushResource, changed ErrorBackground  to ErrorBackgroundBlue and added equivalents for Red, Purple and Green.
- Added LastErrorColor property to ShellViewModel which is databound to the error bar background, and provides a few variations in colour. At present, it returns Purple on a TimeOutException and Red on a WebException, and Blue otherwise.
- Modified the CloseButtonStyle to deal with an ugly mouse-over effect that's come about due to the colour change. I am really unfamiliar with WPF and XAML and this seems a bit hacky, so please amend if necessary. But at present, without this, the button shows a blue background regardless of the colour of the bar.

## Further Suggestions

- The resource dictionary call in ShellViewModel is not great. Someone should restructure this and expose the brush resources in a dedicated file somewhere.
- Error exceptions could be improved in general. It seems a lot of calls to ShowError pass "null" as an exception or otherwise lose useful information. If we better organised and categorized error exceptions, or even just passed a normalised string resource as the message within a new Exception, we could identify them at ShellViewModel level and have more bespoke colouring (depends how much colouring grading is really necessary). Personally, I think why not write some Exception classes for every type of error that may be shown to the user?

## New or Changed Features

 - Error message bar changes colour for several different error types