### PR TITLE
Issue #111: "Save downloaded media with post date as modification timestamp"

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
@@ -225,7 +225,7 @@ namespace TumblThree.Applications.Crawler
             }
         }
 
-        protected void AddTumblrPhotoUrl(string post)
+        protected void AddTumblrPhotoUrl(string post, int? postTimestamp)
         {
             foreach (string imageUrl in TumblrParser.SearchForTumblrPhotoUrl(post))
             {
@@ -235,11 +235,11 @@ namespace TumblThree.Applications.Crawler
                 url = ResizeTumblrImageUrl(url);
                 url = RetrieveOriginalImageUrl(url, 2000, 3000);
                 // TODO: postID
-                AddToDownloadList(new PhotoPost(url, Guid.NewGuid().ToString("N"), BuildFileName(url, (Post)null, -1)));
+                AddToDownloadList(new PhotoPost(url, Guid.NewGuid().ToString("N"), postTimestamp?.ToString(), BuildFileName(url, (Post)null, -1)));
             }
         }
 
-        protected void AddTumblrVideoUrl(string post)
+        protected void AddTumblrVideoUrl(string post, int? postTimestamp)
         {
             foreach (string videoUrl in TumblrParser.SearchForTumblrVideoUrl(post))
             {
@@ -249,7 +249,7 @@ namespace TumblThree.Applications.Crawler
                     url += "_480";
                 }
 
-                AddToDownloadList(new VideoPost("https://vtt.tumblr.com/" + url + ".mp4", Guid.NewGuid().ToString("N"), BuildFileName("https://vtt.tumblr.com/" + url + ".mp4", (Post)null, -1)));
+                AddToDownloadList(new VideoPost("https://vtt.tumblr.com/" + url + ".mp4", Guid.NewGuid().ToString("N"), postTimestamp?.ToString(), BuildFileName("https://vtt.tumblr.com/" + url + ".mp4", (Post)null, -1)));
             }
         }
 
@@ -268,24 +268,24 @@ namespace TumblThree.Applications.Crawler
             }
         }
 
-        protected void AddGenericPhotoUrl(string post)
+        protected void AddGenericPhotoUrl(string post, int? postTimestamp)
         {
             foreach (string imageUrl in TumblrParser.SearchForGenericPhotoUrl(post))
             {
                 if (TumblrParser.IsTumblrUrl(imageUrl)) { continue; }
                 if (CheckIfSkipGif(imageUrl)) { continue; }
 
-                AddToDownloadList(new PhotoPost(imageUrl, Guid.NewGuid().ToString("N"), FileName(imageUrl)));
+                AddToDownloadList(new PhotoPost(imageUrl, Guid.NewGuid().ToString("N"), postTimestamp?.ToString(), FileName(imageUrl)));
             }
         }
 
-        protected void AddGenericVideoUrl(string post)
+        protected void AddGenericVideoUrl(string post, int? postTimestamp)
         {
             foreach (string videoUrl in TumblrParser.SearchForGenericVideoUrl(post))
             {
                 if (TumblrParser.IsTumblrUrl(videoUrl)) { continue; }
 
-                AddToDownloadList(new VideoPost(videoUrl, Guid.NewGuid().ToString("N"), FileName(videoUrl)));
+                AddToDownloadList(new VideoPost(videoUrl, Guid.NewGuid().ToString("N"), postTimestamp?.ToString(), FileName(videoUrl)));
             }
         }
 

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrBlogCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrBlogCrawler.cs
@@ -440,7 +440,6 @@ namespace TumblThree.Applications.Crawler
                 if (!PostWithinTimeSpan(post)) { continue; }
                 if (!CheckIfContainsTaggedPost(post)) { continue; }
                 if (!CheckIfDownloadRebloggedPosts(post)) { continue; }
-                string postTimestamp = post.Date;
 
                 try
                 {

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrBlogCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrBlogCrawler.cs
@@ -440,6 +440,7 @@ namespace TumblThree.Applications.Crawler
                 if (!PostWithinTimeSpan(post)) { continue; }
                 if (!CheckIfContainsTaggedPost(post)) { continue; }
                 if (!CheckIfDownloadRebloggedPosts(post)) { continue; }
+                string postTimestamp = post.Date;
 
                 try
                 {
@@ -692,17 +693,17 @@ namespace TumblThree.Applications.Crawler
 
         private void AddInlinePhotoUrl(Post post)
         {
-            AddTumblrPhotoUrl(InlineSearch(post));
+            AddTumblrPhotoUrl(InlineSearch(post), post.UnixTimestamp);
         }
 
         private void AddInlineVideoUrl(Post post)
         {
-            AddTumblrVideoUrl(InlineSearch(post));
+            AddTumblrVideoUrl(InlineSearch(post), post.UnixTimestamp);
         }
 
         private void AddGenericInlineVideoUrl(Post post)
         {
-            AddGenericVideoUrl(InlineSearch(post));
+            AddGenericVideoUrl(InlineSearch(post), post.UnixTimestamp);
         }
 
         private void AddInlineVideoUrlsToDownloader(HashSet<string> videoUrls, Post post)
@@ -744,7 +745,7 @@ namespace TumblThree.Applications.Crawler
 
         private void AddGenericInlinePhotoUrl(Post post)
         {
-            AddGenericPhotoUrl(InlineSearch(post));
+            AddGenericPhotoUrl(InlineSearch(post), post.UnixTimestamp);
         }
 
         private void AddVideoUrl(Post post)

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrHiddenCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrHiddenCrawler.cs
@@ -474,12 +474,12 @@ namespace TumblThree.Applications.Crawler
 
         private void AddInlinePhotoUrl(Post post)
         {
-            AddTumblrPhotoUrl(InlineSearch(post));
+            AddTumblrPhotoUrl(InlineSearch(post), post.Timestamp);
         }
 
         private void AddGenericInlinePhotoUrl(Post post)
         {
-            AddTumblrPhotoUrl(InlineSearch(post));
+            AddTumblrPhotoUrl(InlineSearch(post), post.Timestamp);
         }
 
         private void AddVideoUrlToDownloadList(Post post)
@@ -497,7 +497,7 @@ namespace TumblThree.Applications.Crawler
 
             //var videoUrls = new HashSet<string>();
 
-            AddTumblrVideoUrl(InlineSearch(postCopy));
+            AddTumblrVideoUrl(InlineSearch(postCopy), post.Timestamp);
             AddInlineTumblrVideoUrl(InlineSearch(postCopy), TumblrParser.GetTumblrVVideoUrlRegex());
             if (Blog.RegExVideos)
             {
@@ -528,7 +528,7 @@ namespace TumblThree.Applications.Crawler
 
         private void AddGenericInlineVideoUrl(Post post)
         {
-            AddGenericVideoUrl(InlineSearch(post));
+            AddGenericVideoUrl(InlineSearch(post), post.Timestamp);
         }
 
         private void AddInlineVideoUrlsToDownloader(HashSet<string> videoUrls, Post post)

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrLikedByCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrLikedByCrawler.cs
@@ -258,11 +258,11 @@ namespace TumblThree.Applications.Crawler
                 return;
             }
 
-            AddTumblrPhotoUrl(document);
+            AddTumblrPhotoUrl(document, null);
 
             if (Blog.RegExPhotos)
             {
-                AddGenericPhotoUrl(document);
+                AddGenericPhotoUrl(document, null);
             }
         }
 
@@ -273,12 +273,12 @@ namespace TumblThree.Applications.Crawler
                 return;
             }
 
-            AddTumblrVideoUrl(document);
+            AddTumblrVideoUrl(document, null);
             AddInlineTumblrVideoUrl(document, TumblrParser.GetTumblrVVideoUrlRegex());
 
             if (Blog.RegExVideos)
             {
-                AddGenericVideoUrl(document);
+                AddGenericVideoUrl(document, null);
             }
         }
 


### PR DESCRIPTION
## Title

Issue #111: "Save downloaded media with post date as modification timestamp"

## Description

When inlined (HTML-embedded) media is downloaded from a post, it's timestamp is set to the current date and time. The preferred outcome is that it's timestamp is the same as the post's timestamp.

## Issue Resolution

This Pull Request Fixes #111 Save downloaded media with post date as modification timestamp

## Proposed Changes

In AbstractTumblrCrawler I have made some changes to a few methods (AddPhotoUrl, AddVideoUrl, etc) - which are called by TumblrBlogCrawler methods named "AddInline..." or "AddGenericInline..." - by including a parameter "postTimestamp" to pass through to the "PhotoPost" or "VideoPost" constructor. This parameter is nullable since there are cases where an entire document string is passed through and no post timestamp can be associated with it.

## New or Changed Features

Embedded media is timestamped according to the post where it originates.