### PR TITLE
Fix tumblr %b argument in filename template

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
@@ -322,7 +322,7 @@ namespace TumblThree.Applications.Crawler
                 RegularTitle = p.Title,
                 RebloggedFromName = p.RebloggedFromName,
                 ReblogKey = p.ReblogKey,
-                Tumblelog = new TumbleLog2() { Name = p.Publisher }
+                Tumblelog = new TumbleLog2() { Name = p.Tumblelog}
             };
         }
 
@@ -471,7 +471,7 @@ namespace TumblThree.Applications.Crawler
                 post = new TumblrSvcJson.Post() { Date = DateTime.MinValue.ToString("R"), Type = "", Id = "",
                     Tags = new List<string>(), Slug = "", Title = "", RebloggedFromName = "", ReblogKey = "" };
             }
-            return BuildFileNameCore(url, post.Publisher, post.Date, post.Timestamp, index, post.Type, post.Id, post.Tags, post.Slug, post.Title, post.RebloggedFromName, post.ReblogKey);
+            return BuildFileNameCore(url, post.Tumblelog, post.Date, post.Timestamp, index, post.Type, post.Id, post.Tags, post.Slug, post.Title, post.RebloggedFromName, post.ReblogKey);
         }
 
         private static string ReplaceCI(string input, string search, string replacement)

--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
@@ -322,7 +322,7 @@ namespace TumblThree.Applications.Crawler
                 RegularTitle = p.Title,
                 RebloggedFromName = p.RebloggedFromName,
                 ReblogKey = p.ReblogKey,
-                Submitter = p.Publisher
+                Tumblelog = new TumbleLog2() { Name = p.Publisher }
             };
         }
 
@@ -461,7 +461,7 @@ namespace TumblThree.Applications.Crawler
                 post = new Post() { Date = DateTime.MinValue.ToString("R"), Type = "", Id = "",
                     Tags = new List<string>(), Slug = "", RegularTitle = "", RebloggedFromName = "", ReblogKey = "" };
             }
-            return BuildFileNameCore(url, post.Submitter, post.Date, post.UnixTimestamp, index, post.Type, post.Id, post.Tags, post.Slug, post.RegularTitle, post.RebloggedFromName, post.ReblogKey);
+            return BuildFileNameCore(url, post.Tumblelog.Name, post.Date, post.UnixTimestamp, index, post.Type, post.Id, post.Tags, post.Slug, post.RegularTitle, post.RebloggedFromName, post.ReblogKey);
         }
 
         protected string BuildFileName(string url, TumblrSvcJson.Post post, int index)

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrSearchCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrSearchCrawler.cs
@@ -250,7 +250,7 @@ namespace TumblThree.Applications.Crawler
                                 RebloggedFromName = "",
                                 ReblogKey = HasProperty(post, "reblog_key") ? post.reblog_key : post.reblogKey,
                                 UnixTimestamp = (int)post.timestamp,
-                                Submitter = HasProperty(post, "blog_name") ? post.blog_name : post.blogName,
+                                Tumblelog = new TumbleLog2() { Name = HasProperty(post, "blog_name") ? post.blog_name : post.blogName },
                                 UrlWithSlug = HasProperty(post, "post_url") ? post.post_url : post.postUrl
                             };
                             index += (post.content.Count > 1) ? 1 : 0;

--- a/src/TumblThree/TumblThree.Applications/Crawler/TumblrTagSearchCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TumblrTagSearchCrawler.cs
@@ -191,7 +191,7 @@ namespace TumblThree.Applications.Crawler
                                 RebloggedFromName = "",
                                 ReblogKey = post.ReblogKey,
                                 UnixTimestamp = post.Timestamp,
-                                Submitter = post.BlogName
+                                Tumblelog = new TumbleLog2(){ Name = post.BlogName }
                             };
                             index += (post.Content.Count > 1) ? 1 : 0;
                             DownloadMedia(content, data, index);
@@ -241,7 +241,7 @@ namespace TumblThree.Applications.Crawler
                                 RebloggedFromName = "",
                                 ReblogKey = data.ReblogKey,
                                 UnixTimestamp = data.Timestamp,
-                                Submitter = data.BlogName
+                                Tumblelog = new TumbleLog2() { Name = data.BlogName }
                             };
                             index += (data.Content.Count > 1) ? 1 : 0;
                             DownloadMedia(content, post, index);

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/Post.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/Post.cs
@@ -244,9 +244,6 @@ namespace TumblThree.Applications.DataModels.TumblrApiJson
         [DataMember(Name = "conversation", EmitDefaultValue = false)]
         public List<Conversation> Conversation { get; set; }
 
-        [DataMember(Name = "submitter", EmitDefaultValue = false)]
-        public string Submitter { get; set; }
-
         [DataMember(Name = "question", EmitDefaultValue = false)]
         public string Question { get; set; }
 
@@ -345,7 +342,6 @@ namespace TumblThree.Applications.DataModels.TumblrApiJson
             VideoPlayer500 = string.Empty;
             VideoPlayer250 = string.Empty;
             Conversation = new List<Conversation>();
-            Submitter = string.Empty;
             Question = string.Empty;
             Answer = string.Empty;
         }

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/TumbleLog.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/TumbleLog.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace TumblThree.Applications.DataModels.TumblrApiJson
 {
+    [DataContract]
     public class TumbleLog
     {
         [DataMember(Name = "title", EmitDefaultValue = false)]

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/TumbleLog2.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrApi/TumbleLog2.cs
@@ -2,6 +2,7 @@
 
 namespace TumblThree.Applications.DataModels.TumblrApiJson
 {
+    [DataContract]
     public class TumbleLog2
     {
         [DataMember(Name = "title", EmitDefaultValue = false)]

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrSvc/TumblrSvcJson.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrSvc/TumblrSvcJson.cs
@@ -801,9 +801,6 @@ namespace TumblThree.Applications.DataModels.TumblrSvcJson
         [DataMember(Name = "excerpt", EmitDefaultValue = false)]
         public string Excerpt { get; set; }
 
-        [DataMember(Name = "publisher", EmitDefaultValue = false)]
-        public string Publisher { get; set; }
-
         [DataMember(Name = "description", EmitDefaultValue = false)]
         public string Description { get; set; }
 


### PR DESCRIPTION
## Title

Fix tumblr %b argument in filename download template

## Description

Tried to set %b in filename for tumblr downloader, but got empty string (i.e. %f-%b returns "tumblr_<uid>-.jpg" for post photo). So I looked into code and in process of fixing found that tumblr api doesn't return `Submitter` property in json response from blog that I tried to download neither from [tumblr demo blog](https://demo.tumblr.com/api/read/json). So instead of `Submitter` property of post data model I changed code to use `Tumblelog` property which contain `Name` property which store blog name. Also found that json response wasn't converted to `TumblrApiJson` class correctly. `TumbleLog` propery of `TumblrApiJson` class had empty fields despite the fact that the fields in the response were present. Same situation with `TumbleLog` propery of tubmlr `Post` class.

## Issue Resolution

No issue for this PR.

## Proposed Changes

 - using `Post.Tumblelog.name` property instead `Post.Submitter`.
 - added `[DataContract]` attribute to `TumbleLog` and `TumbleLog2` classes to fix `AbstractCrawler.ConvertJsonToClass<T>(json)` converter method.

## Additional info
Well, I didn't test fixes with many blog. Tested with first found blog `https://funnytwittertweets.tumblr.com/`, with [tumblr demo blog](https://demo.tumblr.com) and with the blog that I tried to download. Default settings, except filename template setting, which I set to `%b-%f`. Worked as it should.

Also, this is my first PR, sorry if something wrong with it.

### Non related info
[Wiki](https://github.com/TumblThreeApp/TumblThree/wiki/File-rename-functionality) page says that `%d  post date (yyyyMMddHHmmss)` but in reality `AbstractTumblrCrawler.BuildFileNameCore(*)` method is using `DateTime.Parse(date).ToString("yyyyMMdd")` output format.
