### PR TITLE
Download .pngs instead of .pnjs

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
@@ -442,7 +442,8 @@ namespace TumblThree.Applications.Crawler
                 ImageResponse imgRsp = DeserializeImageResponse(extracted);
                 int maxWidth = imgRsp.Images.Max(x => x.Width);
                 Image img = imgRsp.Images.FirstOrDefault(x => x.Width == maxWidth);
-                return string.IsNullOrEmpty(img?.MediaKey) ? url : img.Url;
+                url = string.IsNullOrEmpty(img?.MediaKey) ? url : img.Url;
+                return url.EndsWith(".pnj") ? url.Substring(0, url.Length - 4) + ".png" : url;
             }
             catch (Exception ex)
             {

--- a/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/AbstractTumblrCrawler.cs
@@ -382,6 +382,7 @@ namespace TumblThree.Applications.Crawler
 
         protected string RetrieveOriginalImageUrl(string url, int width, int height, bool isInline)
         {
+            if (url.EndsWith(".pnj")) url = url.Substring(0, url.Length - 4) + ".png";
             if (width > height) { (width, height) = (height, width); }
             if (ShellService.Settings.ImageSize != "best"
                 || !isInline && !url.Contains("/s1280x1920/")
@@ -397,6 +398,7 @@ namespace TumblThree.Applications.Crawler
             {
                 url = url.Replace("/s1280x1920/", (width <= 2048 && height <= 3072) ? "/s2048x3072/" : "/s99999x99999/");
             }
+
             string pageContent = "";
             int errCnt = 0;
             Exception lastError = null;
@@ -442,8 +444,11 @@ namespace TumblThree.Applications.Crawler
                 ImageResponse imgRsp = DeserializeImageResponse(extracted);
                 int maxWidth = imgRsp.Images.Max(x => x.Width);
                 Image img = imgRsp.Images.FirstOrDefault(x => x.Width == maxWidth);
-                url = string.IsNullOrEmpty(img?.MediaKey) ? url : img.Url;
-                return url.EndsWith(".pnj") ? url.Substring(0, url.Length - 4) + ".png" : url;
+
+                if (string.IsNullOrEmpty(img?.MediaKey))
+                    return url;
+
+                return img.Url.EndsWith(".pnj") ? img.Url.Substring(0, img.Url.Length - 4) + ".png" : img.Url;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #231. It seems that if the URL Tumblr returns ends in .jpg then the image was uploaded in jpg format in the first place, so there is no point in downloading the .png. Otherwise if it ends in .pnj, then downloading the .png is worth it!