### PR TITLE
[WIP] Don't save incomplete downloaded files

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Downloader/AbstractDownloader.cs
+++ b/src/TumblThree/TumblThree.Applications/Downloader/AbstractDownloader.cs
@@ -289,7 +289,7 @@ namespace TumblThree.Applications.Downloader
                 string fileName = FileName(downloadItem);
                 UpdateProgressQueueInformation(Resources.ProgressSkipFile, fileName);
             }
-            else if (!shellService.Settings.LoadAllDatabases && blog.CheckDirectoryForFiles && (blog.CheckIfBlogShouldCheckDirectory(FileNameUrl(downloadItem), FileNameNew(downloadItem))
+            /*else if (!shellService.Settings.LoadAllDatabases && blog.CheckDirectoryForFiles && (blog.CheckIfBlogShouldCheckDirectory(FileNameUrl(downloadItem), FileNameNew(downloadItem))
                 || blog.CheckIfBlogShouldCheckDirectory(FileName(downloadItem), FileNameNew(downloadItem))))
             {
                 string fileName = AddFileToDb(downloadItem);
@@ -299,7 +299,7 @@ namespace TumblThree.Applications.Downloader
             {
                 string fileName = AddFileToDb(downloadItem);
                 UpdateProgressQueueInformation(Resources.ProgressSkipFile, fileName);
-            }
+            }*/
             else
             {
                 string blogDownloadLocation = blog.DownloadLocation();
@@ -310,6 +310,7 @@ namespace TumblThree.Applications.Downloader
                 UpdateProgressQueueInformation(Resources.ProgressDownloadImage, fileName);
                 if (!await DownloadBinaryFileAsync(fileLocation, fileLocationUrlList, Url(downloadItem)))
                 {
+                    RemoveFileFromDb(FileNameUrl(downloadItem)); // TODO: Temp plan, the addition should happen only when the download is successful.
                     return false;
                 }
 
@@ -351,6 +352,10 @@ namespace TumblThree.Applications.Downloader
                 return downloadItem.Filename;
             }
             return files.AddFileToDb(FileNameUrl(downloadItem), downloadItem.Filename, AppendTemplate);
+        }
+        protected void RemoveFileFromDb(string fileNameUrl)
+        {
+            files.RemoveFileFromDb(fileNameUrl);
         }
 
         public bool CheckIfFileExistsInDB(string filenameUrl)

--- a/src/TumblThree/TumblThree.Applications/Downloader/FileDownloader.cs
+++ b/src/TumblThree/TumblThree.Applications/Downloader/FileDownloader.cs
@@ -55,7 +55,7 @@ namespace TumblThree.Applications.Downloader
 
             if (ct.IsCancellationRequested) return false;
 
-            var fileMode = totalBytesReceived > 0 ? FileMode.Append : FileMode.Create;
+            var fileMode = File.Exists(destinationPath) ? FileMode.Append : FileMode.Create;
 
             var fileStream = new FileStream(destinationPath, fileMode, FileAccess.Write, FileShare.Read, bufferSize, true);
             try
@@ -131,6 +131,8 @@ namespace TumblThree.Applications.Downloader
                         }
                         else
                         {
+                            fileStream?.Dispose();
+                            File.Delete(destinationPath);
                             throw;
                         }
                     }

--- a/src/TumblThree/TumblThree.Domain/Models/Files/Files.cs
+++ b/src/TumblThree/TumblThree.Domain/Models/Files/Files.cs
@@ -75,6 +75,14 @@ namespace TumblThree.Domain.Models.Files
                 isDirty = true;
             }
         }
+        public void RemoveFileFromDb(string fileNameUrl)
+        {
+            lock (_lockList)
+            {
+                entries.RemoveWhere(i => i.Link == fileNameUrl);
+                isDirty = true;
+            }
+        }
 
         public string AddFileToDb(string fileNameUrl, string fileName, string appendTemplate)
         {

--- a/src/TumblThree/TumblThree.Domain/Models/Files/IFiles.cs
+++ b/src/TumblThree/TumblThree.Domain/Models/Files/IFiles.cs
@@ -20,6 +20,7 @@ namespace TumblThree.Domain.Models.Files
         void AddFileToDb(string fileNameUrl, string fileName);
 
         string AddFileToDb(string fileNameUrl, string fileName, string appendTemplate);
+        void RemoveFileFromDb(string fileNameUrl);
 
         bool CheckIfFileExistsInDB(string filenameUrl);
 


### PR DESCRIPTION
## Description

This seems to ensure that no 0-byte files are present. However, clicking stop button still cause some JPEG files to be incomplete while downloading.

CheckDirectoryForFiles option is not visible since 2017, I don't know why.

For coding discussions, any suitable place? Issues, GitHub discussion (not opened, I suggest turning it on and provide some topic), or something else?

## Issue Resolution

#257.

## Proposed Changes

## New or Changed Features

_Does this PR provide new or changed features or enhancements? If so, what is included in this PR?_
