### PR TITLE
Make the feedback window have the correct parent window

### DIFF
--- a/src/TumblThree/TumblThree.Applications/ViewModels/AboutViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/AboutViewModel.cs
@@ -118,7 +118,7 @@ namespace TumblThree.Applications.ViewModels
         private void Feedback()
         {
             FeedbackViewModel feedbackViewModel = _feedbackViewModelFactory.CreateExport().Value;
-            feedbackViewModel.ShowDialog(this);
+            feedbackViewModel.ShowDialog(View);
         }
 
         private async Task CheckForUpdatesComplete(Task<string> task)


### PR DESCRIPTION
## Description

It looks like the Feedback window is not getting the correct owner.
https://stackoverflow.com/questions/816885/form-showdialog-or-form-showdialogthis involve some similar reports, but these answers is not working for the project.
https://blog.csdn.net/baizebing/article/details/89199637 provide this solution.

## Issue Resolution

1. Click the About, and then click the Feedback button.
2. Click the taskbar icon of the main window, you will get the main window that is frozen and the feedback window is not visible. This is likely to happen after app switch or "Show Desktop". You may retrieve this window with the uncommon Alt + Esc hotkey.

## Proposed Changes

## New or Changed Features
