### PR TITLE
closes #473 - Change user.Legacy.Name to user.Legacy.ScreenName

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Crawler/TwitterCrawler.cs
+++ b/src/TumblThree/TumblThree.Applications/Crawler/TwitterCrawler.cs
@@ -975,7 +975,7 @@ namespace TumblThree.Applications.Crawler
             //else 
             if (reblogged)
             {
-                reblogName = user.Legacy.Name;
+                reblogName = user.Legacy.ScreenName;
                 reblogId = (post.Legacy.RetweetedStatusResult.Result.Legacy ?? post.Legacy.RetweetedStatusResult.Result.TweetWithVisibilityResults.Legacy).IdStr;
             }
             var tags = GetTags(post);


### PR DESCRIPTION
## Checklist

_Confirm you have completed the following actions prior to submitting this PR._

 - [x] There is an existing issue report for this PR.
 - [x] I have forked this project.
 - [x] I have created a feature branch.
 - [x] My changes have been committed.
 - [x] I have pushed my changes to the branch.

## Title

Change user.Legacy.Name to user.Legacy.ScreenName

## Description

user.Legacy.Name is a user-determined and (frequently) modifiable page name, whereas ScreenName is the name of the account and is what was used before the data structures changed

## Issue Resolution

This Pull Request Fixes #473 

## Proposed Changes

Change user.Legacy.Name to user.Legacy.ScreenName in the TwitterCrawler.cs

## New or Changed Features

Fixes the attribute used for %o replacement
