### PR TITLE
Added another way to install TumblThree to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ It is the code rewrite of [TumblTwo](https://github.com/johanneszab/TumblTwo), u
 
 Latest versions can be found [here](https://github.com/TumblThreeApp/TumblThree/releases).
 
+TumblThree can also be installed using Chocolatey:
+```
+choco install tumblthree
+```
+
 Please keep in mind that probably only the latest version is functioning properly since the platforms evolve and from time to time change their data structures which makes changes in TumblThree necessary again. So update your application regularly.
 
 ## Application Usage and Getting Started


### PR DESCRIPTION
I found TumblThree very useful, so I added it to the Windows package manager Chocolatey.

The package page can be found here: https://community.chocolatey.org/packages/tumblthree

## Checklist

_Confirm you have completed the following actions prior to submitting this PR._

 - [ ] There is an existing issue report for this PR.
 - [x] I have forked this project.
 - [x] I have created a feature branch.
 - [x] My changes have been committed.
 - [x] I have pushed my changes to the branch.

## Title

Add Chocolatey installation method to TumblThree documentation

## Description

This PR adds an additional installation method for TumblThree using Chocolatey, a popular Windows package manager. By including this installation method, users can easily install and update TumblThree via the Chocolatey package management system. This change enhances the accessibility and convenience for Windows users.

## Issue Resolution

_Tell us which issue this PR fixes._

N/A

## Proposed Changes

_List your proposed changes below._

 - Added Chocolatey installation instructions to the README file.
 - Included a link to the TumblThree package page on Chocolatey.

## New or Changed Features

_Does this PR provide new or changed features or enhancements? If so, what is included in this PR?_

 - New installation method via Chocolatey
 - Updated documentation with step-by-step installation instructions