### PR TITLE
add JsonConverter to handle fields being a single or array instance.

### DIFF
--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrTaggedSearch/TumblrTaggedSearchJson.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrTaggedSearch/TumblrTaggedSearchJson.cs
@@ -362,6 +362,7 @@ namespace TumblThree.Applications.DataModels.TumblrTaggedSearchJson
         public string Type { get; set; }
 
         [DataMember(Name = "media", EmitDefaultValue = false)]
+        [JsonConverter(typeof(SingleOrArrayConverter<Medium>))]
         public IList<Medium> Media { get; set; }
 
         [DataMember(Name = "colors", EmitDefaultValue = false)]
@@ -389,6 +390,7 @@ namespace TumblThree.Applications.DataModels.TumblrTaggedSearchJson
         public Metadata Metadata { get; set; }
 
         [DataMember(Name = "attribution", EmitDefaultValue = false)]
+        [JsonConverter(typeof(SingleOrArrayConverter<Attribution>))]
         public Attribution Attribution { get; set; }
     }
 


### PR DESCRIPTION
TumblrSearchJson does the same thing (the objects are identical except for one field)

refs #579

## Checklist

_Confirm you have completed the following actions prior to submitting this PR._

 - [x] There is an existing issue report for this PR.
 - [x] I have forked this project.
 - [x] I have created a feature branch.
 - [x] My changes have been committed.
 - [x] I have pushed my changes to the branch.

## Title

Fix issue with TumblrTagSearch not handling arrays of some objects

## Issue Resolution

This Pull Request Fixes #579 
